### PR TITLE
Ensure knex connection is destroyed

### DIFF
--- a/src/connector/read.ts
+++ b/src/connector/read.ts
@@ -150,6 +150,8 @@ class Reader {
       }
     }
 
+    await this.knex.destroy()
+
     return this.database
   }
 

--- a/src/connector/write.ts
+++ b/src/connector/write.ts
@@ -114,6 +114,8 @@ class Writer {
         }
       }
     })
+
+    await this.knex.destroy()
   }
 
   private getTableName (name: string) {


### PR DESCRIPTION
When running `migrate()` as part of a script, it will hang indefinitely as knex starts up some connections in the background. To ensure those connections get closed, one can use `knex.destroy()`.