### PR TITLE
Fix lowercaseNames option

### DIFF
--- a/src/abstract/generateAbstractDatabase.ts
+++ b/src/abstract/generateAbstractDatabase.ts
@@ -80,7 +80,11 @@ class AbstractDatabaseBuilder {
 
   constructor (schema: GraphQLSchema, options: GenerateAbstractDatabaseOptions) {
     this.schema = schema
-    this.lowercaseNames = options.lowercaseNames || defaultOptions.lowercaseNames as boolean
+    if (typeof options.lowercaseNames !== 'undefined') {
+      this.lowercaseNames = options.lowercaseNames as boolean
+    } else {
+      this.lowercaseNames = defaultOptions.lowercaseNames as boolean
+    }
     this.scalarMap = options.scalarMap as ScalarMap | null
     this.mapListToJson = options.mapListToJson || defaultOptions.mapListToJson as boolean
     this.typeMap = this.schema.getTypeMap()

--- a/src/abstract/generateAbstractDatabase.ts
+++ b/src/abstract/generateAbstractDatabase.ts
@@ -248,7 +248,7 @@ class AbstractDatabaseBuilder {
         }
 
         // Foreign Field
-        const foreignKey = onSameType ? field.name : annotations.manyToMany || this.currentTable.name.toLowerCase()
+        const foreignKey = onSameType ? field.name : annotations.manyToMany || this.currentTable.name
         const foreignField = foreignType.getFields()[foreignKey]
         if (!foreignField) { return null }
         // @db.foreign
@@ -310,7 +310,7 @@ class AbstractDatabaseBuilder {
         // Index
         joinTable.indexes.push({
           columns: descriptors.map((d) => d.name),
-          name: `${joinTable.name}_${descriptors.map((d) => d.name).join('_')}_index`.toLowerCase().substr(0, 63),
+          name: `${joinTable.name}_${descriptors.map((d) => d.name).join('_')}_index`.substr(0, 63),
           type: null,
         })
         return null
@@ -364,7 +364,7 @@ class AbstractDatabaseBuilder {
         }
         index.columns.push(columnName)
         if (!index.name) {
-          index.name = type.defaultName(this.currentTable.name, columnName).toLowerCase().substr(0, 63)
+          index.name = type.defaultName(this.currentTable.name, columnName).substr(0, 63)
         }
       }
     }

--- a/tests/specs/abstract-database.ts
+++ b/tests/specs/abstract-database.ts
@@ -47,6 +47,25 @@ describe('create abstract database', () => {
     expect(colName.comment).toBe('Display name.')
   })
 
+  test('lowercase names', async () => {
+    const schema = buildSchema(`
+      type User {
+        id: ID!
+        fullName: String!
+      }
+    `)
+    const adb = await generateAbstractDatabase(schema, { lowercaseNames: false })
+    expect(adb.tables.length).toBe(1)
+    const [User] = adb.tables
+    expect(User.name).toBe('User')
+    expect(User.columns.length).toBe(2)
+    const [colId, colFullName] = User.columns
+    expect(colId.name).toBe('id')
+    expect(colId.type).toBe('uuid')
+    expect(colFullName.name).toBe('fullName')
+    expect(colFullName.type).toBe('string')
+  })
+
   test('skip table', async () => {
     const schema = buildSchema(`
       """

--- a/tests/specs/abstract-database.ts
+++ b/tests/specs/abstract-database.ts
@@ -47,7 +47,7 @@ describe('create abstract database', () => {
     expect(colName.comment).toBe('Display name.')
   })
 
-  test('lowercase names', async () => {
+  test('lowercase names false', async () => {
     const schema = buildSchema(`
       type User {
         id: ID!
@@ -397,6 +397,39 @@ describe('create abstract database', () => {
     expect(colUserMessages.name).toBe('messages_foreign')
     expect(colUserMessages.type).toBe('uuid')
     expect(colUserMessages.foreign && colUserMessages.foreign.tableName).toBe('user')
+    expect(colUserMessages.foreign && colUserMessages.foreign.columnName).toBe('id')
+  })
+
+  test('many to many with lowercase names false', async () => {
+    const schema = buildSchema(`
+      type User {
+        id: ID!
+        """
+        @db.manyToMany: 'users'
+        """
+        messages: [Message!]!
+      }
+
+      type Message {
+        id: ID!
+        """
+        @db.manyToMany: 'messages'
+        """
+        users: [User]
+      }
+    `)
+    const adb = await generateAbstractDatabase(schema, { lowercaseNames: false })
+    expect(adb.tables.length).toBe(3)
+    const Join = adb.tables[2]
+    expect(Join.name).toBe('Message_users_join_User_messages')
+    const [colMessageUsers, colUserMessages] = Join.columns
+    expect(colMessageUsers.name).toBe('users_foreign')
+    expect(colMessageUsers.type).toBe('uuid')
+    expect(colMessageUsers.foreign && colMessageUsers.foreign.tableName).toBe('Message')
+    expect(colMessageUsers.foreign && colMessageUsers.foreign.columnName).toBe('id')
+    expect(colUserMessages.name).toBe('messages_foreign')
+    expect(colUserMessages.type).toBe('uuid')
+    expect(colUserMessages.foreign && colUserMessages.foreign.tableName).toBe('User')
     expect(colUserMessages.foreign && colUserMessages.foreign.columnName).toBe('id')
   })
 


### PR DESCRIPTION
When setting `lowercaseNames: false` in configuration, the value gets ignored. This fixes the problem.